### PR TITLE
feat: add basic support for ruby

### DIFF
--- a/lua/nvim-yati/configs/ruby.lua
+++ b/lua/nvim-yati/configs/ruby.lua
@@ -1,0 +1,63 @@
+local ch = require("nvim-yati.handlers.common")
+
+---@type YatiBuiltinConfig
+local config = {
+  scope = {
+    "do_block",
+    "block",
+    "method",
+    "module",
+    "if",
+    "for",
+    "until",
+    "class",
+    "case_match",
+    "case",
+    "in_clause",
+    "while",
+    "when",
+    "begin",
+    "block_parameters",
+    "destructured_parameter",
+    "parenthesized_statements",
+    "argument_list",
+    "array",
+    "hash",
+  },
+  scope_open = {
+    "call",
+    "assignment",
+    "operator_assignment",
+    "else",
+    "elsif",
+  },
+  indent_list = {
+    "call",
+    "block_parameters",
+    "argument_list",
+    "array",
+    "hash",
+  },
+  indent_align = {
+    "block_parameters",
+    "argument_list",
+    "array",
+    "hash",
+  },
+  dedent_child = {
+    ["if"] = { "else", "elsif" },
+    case = { "when", "else" },
+    case_match = { "in_clause" },
+  },
+  ignore = { "then", "do" },
+  handlers = {
+    on_initial = {
+      ch.multiline_string_literal("heredoc_content"),
+    },
+    on_traverse = {
+      ch.chained_field_call("argument_list", "call", "method"),
+    },
+  },
+}
+
+return config

--- a/lua/nvim-yati/configs/vue.lua
+++ b/lua/nvim-yati/configs/vue.lua
@@ -7,6 +7,7 @@ local config = {
     "end_tag",
     "interpolation",
     "self_closing_tag",
+    "interpolation",
   },
   ignore = { "text", "raw_text" },
 }

--- a/lua/nvim-yati/context.lua
+++ b/lua/nvim-yati/context.lua
@@ -282,7 +282,7 @@ function Context:set(indent)
   self.computed_indent = indent
 end
 
----@param new_node userdata
+---@param new_node userdata|nil
 function Context:relocate(new_node, follow_parent)
   if new_node ~= self.node then
     if follow_parent then

--- a/tests/fixtures/ruby/assign_hang.fail.rb
+++ b/tests/fixtures/ruby/assign_hang.fail.rb
@@ -1,0 +1,13 @@
+variable = if something == something_else
+             MARKER
+             something_else
+           elsif other == none
+             none
+           else
+             other
+           end
+
+variable = while
+             MARKER
+             break something
+           end

--- a/tests/fixtures/ruby/basic.rb
+++ b/tests/fixtures/ruby/basic.rb
@@ -1,0 +1,151 @@
+if foo then
+  bar
+end
+
+if foo
+  bar
+else
+  baz
+end
+
+bar if foo
+something_else
+
+for a in 1..5 do
+  puts i
+end
+
+until other
+  MARKER
+end
+
+def one
+  two = <<-THREE
+  four
+  THREE
+end
+
+def one
+  two = << THREE
+  four
+  THREE
+end
+
+def one
+  two = <<~THREE
+  four
+  THREE
+  # Some comments
+end
+
+def foo
+  <<-EOS
+  one
+  \#{two} three
+    four
+  EOS
+end
+
+def one
+  example do |something|
+    MARKER
+    =begin
+    something that is ignored
+    =end
+  end
+end
+
+class OuterClass
+  private :method
+  def method; end
+  protected
+  def method; end
+  private
+  def method; end
+  public
+  def method; end
+  class InnerClass
+    MARKER
+    def method; end
+    protected
+  end
+end
+
+
+case {a: a}
+in {a:}
+  MARKER
+  p a
+end
+
+some_object
+  .method_one
+  .method_two
+  .method_three
+
+some_object
+  &.method_one
+  &.method_two
+  MARKER
+  .method_three(
+    a,
+    b,
+    MARKER
+  )
+
+while true
+  begin
+    puts %{\#{x}}
+    MARKER
+    rescue ArgumentError
+  end
+end
+
+variable =
+  if condition?
+    MARKER
+    1
+  else
+    2
+  end
+
+variable = # evil comment
+  case something
+  when 'something'
+    MARKER
+    something_else
+  else
+    other
+  end
+
+array = [
+  MARKER
+  :one,
+].each do |x|
+  MARKER
+  puts x.to_s
+end
+
+bla = {
+  :one => [
+    MARKER
+    {:bla => :blub}
+  ],
+  :two => (
+    {:blub => :abc}
+  ),
+  :three => {
+    :blub => :abc
+  },
+  :four => 'five'
+}
+
+foo,
+bar = { # TODO: whether to indent here ?
+        :bar => {
+          :foo => { 'bar' => 'baz' },
+          MARKER
+          :one => 'two',
+          :three => 'four'
+        }
+        }

--- a/tests/fixtures/ruby/blocks.rb
+++ b/tests/fixtures/ruby/blocks.rb
@@ -1,0 +1,34 @@
+a
+  .b
+  .c do |x|
+    something
+  end
+
+a.
+  b.
+  c { |x|
+    something
+  }
+
+@foo ||=
+  something do
+    "other"
+  end
+
+module X
+  Class.new do
+    MARKER
+  end
+end
+
+proc do |(a, b)|
+  puts a
+  MARKER
+  puts b
+end
+
+proc do |a: "asdf", b:|
+  proc do
+    puts a, b
+  end
+end

--- a/tests/fixtures/ruby/hang.rb
+++ b/tests/fixtures/ruby/hang.rb
@@ -1,0 +1,26 @@
+render('product/show',
+       MARKER
+       product: product,
+       on_sale: true,
+       )
+
+x = [1,
+     MARKER
+     2,
+     3,
+]
+
+x = { a: 1,
+      MARKER
+      b: 2,
+      c: 3,
+}
+
+User.new(
+  :first_name => 'Some',
+  :second_name => 'Guy'
+)
+
+User.new(:first_name => 'Some',
+         MARKER
+         :second_name => 'Guy')

--- a/tests/fixtures/ruby/tail_block.rb
+++ b/tests/fixtures/ruby/tail_block.rb
@@ -1,0 +1,8 @@
+def foo
+  opts.on('--coordinator host=HOST[,port=PORT]',
+          'Specify the HOST and the PORT of the coordinator') do |str|
+    MARKRE
+    h = sub_opts_to_hash(str)
+    puts h
+  end
+end

--- a/tests/helper.lua
+++ b/tests/helper.lua
@@ -15,6 +15,7 @@ local test_langs = {
   "json",
   "lua",
   "python",
+  "ruby",
   "rust",
   "toml",
   "tsx",


### PR DESCRIPTION
Currently a POC. Most test cases are copied from [vim-ruby](https://github.com/vim-ruby/vim-ruby) and with some hard cases not passed. 

I suggest using the bundled ruby indentexpr of vim since it doesn't tightly rely on vim syntax and works much better than this.